### PR TITLE
Create separate trend dashboard, graphing key metrics over time.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const DashboardGenerator = require('./src/dashboardGenerator');
+const DashboardTrendGenerator = require('./src/dashboardTrendGenerator');
 const PipelineEventHandler = require('./src/pipelineEventHandler');
 
 const AWS = require('aws-sdk');
@@ -29,6 +30,19 @@ exports.generateDashboard = (event, context, callback) => {
     });
 
     new DashboardGenerator()
+        .run(statePromise)
+        .then(() => callback())
+        .catch(callback);
+};
+
+exports.generateDashboardTrend = (event, context, callback) => {
+    let statePromise = Promise.resolve({
+        event: event,
+        region: AWS.config.region,
+        cloudwatch: new AWS.CloudWatch()
+    });
+
+    new DashboardTrendGenerator()
         .run(statePromise)
         .then(() => callback())
         .catch(callback);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1076 @@
+{
+  "name": "pipeline-dashboard",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@sinonjs/commons": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
+      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      },
+      "dependencies": {
+        "samsam": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+          "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+          "dev": true
+        }
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "app-root-path": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.2.1.tgz",
+      "integrity": "sha512-91IFKeKk7FjfmezPKkwtaRvSpnUc4gDwPAjA1YZ9Gn0q0PPeW+vbeUsZuyDwjI7+QTHhcLen2v25fi/AmhvbJA==",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "aws-sdk": {
+      "version": "2.554.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.554.0.tgz",
+      "integrity": "sha512-23EQhz4pCRwzCRRc40deQgoO2ddCT4ylfoVPAuQKOQA8SZqMCWYGkntHjtNWVMd5zIJzHYt26qo8s8zsorc7Rg==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
+    },
+    "aws-sdk-mock": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-mock/-/aws-sdk-mock-1.7.0.tgz",
+      "integrity": "sha1-dpizuoL0k/cf8GCuISPNCAathnY=",
+      "dev": true,
+      "requires": {
+        "aws-sdk": "^2.3.0",
+        "sinon": "^1.17.3",
+        "traverse": "^0.6.6"
+      },
+      "dependencies": {
+        "sinon": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+          "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+          "dev": true,
+          "requires": {
+            "formatio": "1.1.1",
+            "lolex": "1.3.2",
+            "samsam": "1.1.2",
+            "util": ">=0.10.3 <1"
+          }
+        }
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
+    "chai-jest-snapshot": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chai-jest-snapshot/-/chai-jest-snapshot-2.0.0.tgz",
+      "integrity": "sha512-u8jZZjw/0G1t5A8wDfH6K7DAVfMg3g0dsw9wKQURNUyrZX96VojHNrFMmLirq1m0kOvC5icgL/Qh/fu1MZyvUw==",
+      "dev": true,
+      "requires": {
+        "jest-snapshot": "21.2.1",
+        "lodash.values": "^4.3.0"
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "^7.1.1"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "^0.1.4"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
+    },
+    "dom-serializer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz",
+      "integrity": "sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+          "dev": true
+        },
+        "entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
+    },
+    "dotenv-json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-json/-/dotenv-json-1.0.0.tgz",
+      "integrity": "sha512-jAssr+6r4nKhKRudQ0HOzMskOFFi9+ubXWwmrSGJFgTvpjyPXCXsCsYbjif6mXp7uxA7xY3/LGaiTQukZzSbOQ==",
+      "dev": true
+    },
+    "entities": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+      "dev": true
+    },
+    "es-abstract": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+      "integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.0",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-inspect": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "string.prototype.trimleft": "^2.1.0",
+        "string.prototype.trimright": "^2.1.0"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "formatio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+      "dev": true,
+      "requires": {
+        "samsam": "~1.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+      "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
+      }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-generator-function": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
+      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "jest-diff": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz",
+      "integrity": "sha512-E5fu6r7PvvPr5qAWE1RaUwIh/k6Zx/3OOkZ4rk5dBJkEWRrUuSgbMt2EO8IUTPTd6DOqU3LW6uTIwX5FRvXoFA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "diff": "^3.2.0",
+        "jest-get-type": "^21.2.0",
+        "pretty-format": "^21.2.1"
+      }
+    },
+    "jest-get-type": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+      "dev": true
+    },
+    "jest-matcher-utils": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz",
+      "integrity": "sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "jest-get-type": "^21.2.0",
+        "pretty-format": "^21.2.1"
+      }
+    },
+    "jest-snapshot": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.2.1.tgz",
+      "integrity": "sha512-bpaeBnDpdqaRTzN8tWg0DqOTo2DvD3StOemxn67CUd1p1Po+BUpvePAp44jdJ7Pxcjfg+42o4NHw1SxdCA2rvg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "jest-diff": "^21.2.1",
+        "jest-matcher-utils": "^21.2.1",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^21.2.1"
+      }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "jshint": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.10.2.tgz",
+      "integrity": "sha512-e7KZgCSXMJxznE/4WULzybCMNXNAd/bf5TSrvVEq78Q/K8ZwFpmBqQeDtNiHc3l49nV4E/+YeHU/JZjSUIrLAA==",
+      "dev": true,
+      "requires": {
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "~4.17.11",
+        "minimatch": "~3.0.2",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
+      }
+    },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
+    "lambda-leak": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lambda-leak/-/lambda-leak-2.0.0.tgz",
+      "integrity": "sha1-dxmF02KEh/boha+uK1RRDc+yzX4=",
+      "dev": true
+    },
+    "lambda-tester": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/lambda-tester/-/lambda-tester-3.6.0.tgz",
+      "integrity": "sha512-F2ZTGWCLyIR95o/jWK46V/WnOCFAEUG/m/V7/CLhPJ7PCM+pror1rZ6ujP3TkItSGxUfpJi0kqwidw+M/nEqWw==",
+      "dev": true,
+      "requires": {
+        "app-root-path": "^2.2.1",
+        "dotenv": "^8.0.0",
+        "dotenv-json": "^1.0.0",
+        "lambda-leak": "^2.0.0",
+        "semver": "^6.1.1",
+        "uuid": "^3.3.2",
+        "vandium-utils": "^1.1.1"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.values": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
+      "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c=",
+      "dev": true
+    },
+    "lolex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nise": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
+      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "@sinonjs/formatio": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+          "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1",
+            "@sinonjs/samsam": "^3.1.0"
+          }
+        },
+        "lolex": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+          "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
+          "dev": true
+        }
+      }
+    },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
+      }
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+      "dev": true
+    },
+    "samsam": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+      "dev": true
+    },
+    "sinon": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
+      "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^2.0.0",
+        "diff": "^3.1.0",
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.2.0",
+        "nise": "^1.2.0",
+        "supports-color": "^5.1.0",
+        "type-detect": "^4.0.5"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "sinon-chai": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
+      "integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+      "dev": true
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^2.0.0"
+      }
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "util": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.1.tgz",
+      "integrity": "sha512-MREAtYOp+GTt9/+kwf00IYoHZyjM8VU4aVrkzUlejyqaIjd2GztVl5V9hGXKlvBKE3gENn/FMfHE5v6hElXGcQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "object.entries": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "vandium-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/vandium-utils/-/vandium-utils-1.2.0.tgz",
+      "integrity": "sha1-RHNd5LdkGgXeWevpRfF05YLbT1k=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,12 +12,9 @@
     "package": "npm run package:cfn && npm run package:template",
     "package:cfn": "mkdir -p .out && aws cloudformation package --template-file template.yml --s3-bucket ${npm_package_config_staging_bucket}-${npm_package_config_region} --output-template-file .out/template.yml",
     "package:template": "aws s3 cp .out/template.yml s3://${npm_package_config_staging_bucket}-${npm_package_config_region}/template.yml",
-
     "create-codebuild": "aws cloudformation create-stack --region ${npm_package_config_region} --stack-name pipeline-dashboard-codebuild --template-body file://codebuild.yml --capabilities CAPABILITY_NAMED_IAM ",
     "update-codebuild": "aws cloudformation update-stack --region ${npm_package_config_region} --stack-name pipeline-dashboard-codebuild --template-body file://codebuild.yml --capabilities CAPABILITY_NAMED_IAM --parameters ParameterKey=GitHubToken,UsePreviousValue=true",
-
     "deploy": "aws s3 cp s3://${npm_package_config_staging_bucket}-${npm_package_config_region}/template.yml .out/template.yml && aws cloudformation deploy --template-file .out/template.yml --stack-name $npm_package_config_stack_name --capabilities CAPABILITY_NAMED_IAM --region $npm_package_config_region ",
-
     "test": "node ./node_modules/jshint/bin/jshint index.js src/*.js && node ./node_modules/mocha/bin/_mocha"
   },
   "repository": {

--- a/src/dashboardTrendGenerator.js
+++ b/src/dashboardTrendGenerator.js
@@ -1,0 +1,279 @@
+'use strict';
+
+
+const ANNOTATION_ELITE_COLOUR = '#98df8a';
+const ANNOTATION_HIGH_COLOUR = '#dbdb8d';
+const MEAN_COLOUR = '#2ca02c';
+
+const WIDGET_HEIGHT = 6;
+const WIDGET_WIDTH = 12;
+
+
+// Create a dashboard containing multiple widgets, each based from a consistent template
+// The properties here map the metrics to a readable label
+// unit conversion is used to convert from seconds to a more meaningful unit, based on the metric.
+const MINUTES = {
+    unit: 60,
+    label: 'minutes'
+};
+
+const HOURS = {
+    unit: 60 * 60,
+    label: 'hours'
+};
+
+const DAYS = {
+    unit: 60 * 60 * 24,
+    label: 'days'
+};
+
+const THIRTY_DAYS = 60 * 60 * 24 * 30;
+
+const applyLimits = (state) => {
+    // See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html
+    const maxMetricsPerDash = 500;
+    const metricsPerWidget = 4;
+    const widgetsPerPipeline = 4;
+    const maxPipelines = Math.floor(maxMetricsPerDash / (metricsPerWidget * widgetsPerPipeline));
+
+    if (state.pipelineNames.length > maxPipelines) {
+        console.warn(`Maximum of ${maxPipelines} allowed in a single dashboard.  Some pipelines will not be reported.`);
+    }
+    state.pipelineNames = state.pipelineNames.slice(0, maxPipelines);
+};
+
+function deploymentFrequencyWidget(pipelineName, y, state) {
+    const y_offset = 0;
+    return {
+        "type": "metric",
+        "x": 0,
+        "y": y+y_offset,
+        "width": WIDGET_WIDTH,
+        "height": WIDGET_HEIGHT,
+        "properties": {
+            "metrics": [
+                [{ "expression": "FILL(m2,0)", "id": "e2", "period": DAYS.unit, "region": state.region, "yAxis": "left", "color": "#ff7f0e", "label": "Deployment Frequency" }],
+                [{ "expression": `m6/PERIOD(m6) * ${DAYS.unit}`, "label": "Average (30d)", "id": "e1", "color": MEAN_COLOUR }],
+                ["Pipeline", "SuccessCount", "PipelineName", "my-pipeline", { "period": DAYS.unit, "stat": "Sum", "id": "m2", "visible": false, "label": "Deployments" }],
+                ["...", { "period": THIRTY_DAYS, "stat": "Sum", "id": "m6", "label": "Deployment Freq (30d)", "visible": false }]
+            ],
+            "view": "timeSeries",
+            "region": state.region,
+            "title": `${pipelineName} Frequency`,
+            "period": THIRTY_DAYS,
+            "stacked": false,
+            "yAxis": {
+                "left": {
+                    "label": "deployments / day",
+                    "showUnits": false,
+                    "min": 0
+                },
+                "right": {
+                    "showUnits": true
+                }
+            },
+            "annotations": {
+                "horizontal": [
+                    {
+                        "color": "#98df8a",
+                        "label": "daily",
+                        "value": 1,
+                        "fill": "above"
+                    },
+                    {
+                        "color": "#dbdb8d",
+                        "label": "multiple per month",
+                        "value": 0.1,
+                        "fill": "above"
+                    }
+                ]
+            }
+        }
+    };
+}
+
+function otherWidgets(pipelineName, y, state) {
+
+    return state.widgetMappings.map(mapping => {
+        const region = state.region;
+        const unitConversion = mapping.unitConversion.unit;
+        const label = mapping.label;
+
+        return {
+            "type": "metric",
+            "x": mapping.x,
+            "y": y+mapping.y_offset,
+            "width": WIDGET_WIDTH,
+            "height": WIDGET_HEIGHT,
+            "properties": {
+                "metrics": [
+                    [{ "expression": `m1/${unitConversion}`, "label": `${label}`, "id": "e2", "period": DAYS.unit, "region": region, "yAxis": "left", "color": "#ff7f0e" }],
+                    [{ "expression": `FILL(m4,AVG(m4))/${unitConversion}`, "label": `${label} (30d - p90)`, "id": "e3", "region": region, "yAxis": "left", "color": "#1f77b4" }],
+                    [{ "expression": `FILL(m5,AVG(m5))/${unitConversion}`, "label": `${label} (30d - p10)`, "id": "e4", "region": region, "yAxis": "left", "color": "#1f77b4" }],
+                    [{ "expression": `FILL(m3,AVG(m3))/${unitConversion}`, "label": `${label} (30d - p50)`, "id": "e5", "region": region, "color": MEAN_COLOUR }],
+                    ["Pipeline", mapping.metric, "PipelineName", pipelineName, { "label": `${label}`, "stat": "Average", "color": "#1f77b4", "period": DAYS.unit, "id": "m1", "visible": false }],
+                    ["...", { "stat": "Average", "period": THIRTY_DAYS, "id": "m3", "label": `${label} (30d)`, "visible": false }],
+                    ["...", { "stat": "p90", "period": THIRTY_DAYS, "id": "m4", "visible": false, "label": `${label} (p90)` }],
+                    ["...", { "stat": "p10", "period": THIRTY_DAYS, "id": "m5", "visible": false, "label": `${label} (p10)` }]
+                ],
+                "view": "timeSeries",
+                "region": region,
+                "title": `${pipelineName} ${label}`,
+                "period": THIRTY_DAYS,
+                "stacked": false,
+                "yAxis": {
+                    "left": {
+                        "min": 0,
+                        "label": mapping.unitConversion.label,
+                        "showUnits": false
+                    },
+                    "right": {
+                        "showUnits": true
+                    }
+                },
+                "annotations": mapping.annotations
+            }
+        };
+    });
+
+}
+
+class DashboardTrendGenerator {
+    run(eventPromise) {
+        return eventPromise
+            .then(this.initializeState)
+            .then(this.getPipelines)
+            .then(this.putDashboard);
+    }
+
+
+    initializeState(state) {
+        state.pipelineNames = [];
+
+        state.widgetMappings = [
+            {
+                x: 0+WIDGET_WIDTH,
+                y_offset: 0,
+                label: "Lead Time",
+                metric: "DeliveryLeadTime",
+                unitConversion: MINUTES,
+                annotations: {
+                    "horizontal": [
+                        {
+                            "color": ANNOTATION_ELITE_COLOUR,
+                            "label": "daily",
+                            "value": 1,
+                            "fill": "above"
+                        },
+                        {
+                            "color": ANNOTATION_HIGH_COLOUR,
+                            "label": ">1 per month",
+                            "value": 0.1,
+                            "fill": "above"
+                        }
+                    ]
+                }
+            },
+            {
+                x: 0,
+                y_offset: 0+WIDGET_HEIGHT,
+                label: "MTBF",
+                metric: "GreenTime",
+                unitConversion: DAYS
+            },
+            {
+                x: 0+WIDGET_WIDTH,
+                y_offset: 0+WIDGET_HEIGHT,
+                label: "MTTR",
+                metric: "RedTime",
+                unitConversion: HOURS
+            },
+        ];
+
+        return state;
+    }
+
+    getPipelines(state) {
+        return new Promise(function (resolve, reject) {
+            state.cloudwatch.listMetrics({ "Namespace": "Pipeline" }).eachPage(function (err, data) {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+
+                if (data === null) {
+                    resolve(state);
+                } else {
+                    state.pipelineNames =
+                        data.Metrics.map(m => m.Dimensions.filter(d => d.Name === 'PipelineName').map(d => d.Value))
+                            .reduce((a, b) => a.concat(b), state.pipelineNames);
+                }
+            });
+            
+        });
+    }
+
+
+    putDashboard(state) {
+        state.pipelineNames = [...new Set(state.pipelineNames)].sort();
+        let y = 0; // leave space for the legend on first row
+        let period = 60 * 60 * 24 * 30;
+
+        applyLimits(state);
+
+        let dashboard = {
+            "start": "-P42D",
+            "widgets": [],
+        };
+
+        let x = 0;
+        [
+            {
+                "title": "Deployment Frequency",
+                "description": "How often code is deployed to production."
+            },
+            {
+                "title": "Lead Time",
+                "description": "Time from code commit to running in production, including rework"
+            },
+            {
+                "title": "MTBF",
+                "description": "Mean time between pipeline failures."
+            },
+            {
+                "title": "MTTR",
+                "description": "Mean time to pipeline recovery"
+            }
+        ].forEach(l => {
+            dashboard.widgets.push({
+                "type": "text",
+                "x": x,
+                "y": y,
+                "width": 4,
+                "height": WIDGET_HEIGHT/2,
+                "properties": {
+                    "markdown": `### ${l.title}\n${l.description}`
+                }
+            });
+
+            x += 4;
+        });
+        y += WIDGET_HEIGHT/2;
+
+        let pipelineWidgets = state.pipelineNames.map(pipelineName => {
+            let widget = [deploymentFrequencyWidget(pipelineName,y,state)].concat(otherWidgets(pipelineName,y,state));
+            y += WIDGET_HEIGHT;
+            return widget;
+        });
+
+        // flatten the nested arrays
+        dashboard.widgets = [].concat.apply(dashboard.widgets, pipelineWidgets);
+
+        return state.cloudwatch.putDashboard({
+            'DashboardName': 'PipelineTrends-' + state.region,
+            'DashboardBody': JSON.stringify(dashboard)
+        }).promise();
+    }
+}
+
+module.exports = DashboardTrendGenerator;

--- a/template.yml
+++ b/template.yml
@@ -43,3 +43,18 @@ Resources:
             Schedule: "cron(*/5 * * * ? *)"
       Policies:
       - CloudWatchDashboardPolicy: {}
+  PipelineDashboardTrendGenerator:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      Description: Build CloudWatch Trend dashboard from CloudWatch metrics
+      Handler: index.generateTrendDashboard
+      Runtime: nodejs8.10
+      CodeUri: .
+      Timeout: 60
+      Events:
+        DashboardEventRule:
+          Type: Schedule
+          Properties:
+            Schedule: "cron(*/5 * * * ? *)"
+      Policies:
+      - CloudWatchDashboardPolicy: {}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,16 +1,16 @@
 'use strict';
 
 var AWS = require('aws-sdk-mock');
+var awsSdk = require('aws-sdk');
 var chai = require("chai");
 var sinonChai = require("sinon-chai");
 chai.use(sinonChai);
 var expect = chai.expect;
-var LambdaTester = require( 'lambda-tester' );
-var index = require( '../index' );
+var LambdaTester = require('lambda-tester');
+var index = require('../index');
 var sinon = require('sinon');
 
-
-describe( 'handlePipelineEvent', function() {
+describe('handlePipelineEvent', function () {
     [
         {
             description: "pipeline multiple success",
@@ -47,7 +47,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "SuccessCount",
                         "Unit": "Count",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 1,
                     },
@@ -56,7 +56,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "SuccessCycleTime",
                         "Unit": "Seconds",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 600,
                     },
@@ -65,7 +65,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "SuccessLeadTime",
                         "Unit": "Seconds",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 100,
                     },
@@ -74,7 +74,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "DeliveryLeadTime",
                         "Unit": "Seconds",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 100,
                     }
@@ -110,7 +110,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "SuccessCount",
                         "Unit": "Count",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 1,
                     },
@@ -119,7 +119,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "SuccessLeadTime",
                         "Unit": "Seconds",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 200,
                     }
@@ -147,9 +147,9 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "SuccessCount",
                         "Unit": "Count",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
-                            {Name: "StageName", Value: "commit"},
-                            {Name: "ActionName", Value: "compile"}
+                            { Name: "PipelineName", Value: "my-pipeline" },
+                            { Name: "StageName", Value: "commit" },
+                            { Name: "ActionName", Value: "compile" }
                         ],
                         "Value": 1,
                     }
@@ -176,8 +176,8 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "SuccessCount",
                         "Unit": "Count",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
-                            {Name: "StageName", Value: "commit"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
+                            { Name: "StageName", Value: "commit" },
                         ],
                         "Value": 1,
                     }
@@ -205,9 +205,9 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "FailureCount",
                         "Unit": "Count",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
-                            {Name: "StageName", Value: "commit"},
-                            {Name: "ActionName", Value: "compile"}
+                            { Name: "PipelineName", Value: "my-pipeline" },
+                            { Name: "StageName", Value: "commit" },
+                            { Name: "ActionName", Value: "compile" }
                         ],
                         "Value": 1,
                     }
@@ -234,8 +234,8 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "FailureCount",
                         "Unit": "Count",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
-                            {Name: "StageName", Value: "commit"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
+                            { Name: "StageName", Value: "commit" },
                         ],
                         "Value": 1,
                     }
@@ -270,7 +270,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "FailureCount",
                         "Unit": "Count",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 1,
                     }
@@ -334,7 +334,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "SuccessCount",
                         "Unit": "Count",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 1,
                     },
@@ -343,7 +343,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "RedTime",
                         "Unit": "Seconds",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 400,
                     },
@@ -352,7 +352,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "SuccessCycleTime",
                         "Unit": "Seconds",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 600,
                     },
@@ -361,7 +361,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "SuccessLeadTime",
                         "Unit": "Seconds",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 100,
                     },
@@ -370,7 +370,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "DeliveryLeadTime",
                         "Unit": "Seconds",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 500,
                     }
@@ -421,7 +421,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "FailureCount",
                         "Unit": "Count",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 1,
                     },
@@ -430,7 +430,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "GreenTime",
                         "Unit": "Seconds",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 400,
                     },
@@ -439,7 +439,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "FailureLeadTime",
                         "Unit": "Seconds",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 100,
                     }
@@ -486,7 +486,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "FailureCount",
                         "Unit": "Count",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 1,
                     },
@@ -495,7 +495,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "FailureLeadTime",
                         "Unit": "Seconds",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 100,
                     }
@@ -542,7 +542,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "FailureCount",
                         "Unit": "Count",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 1,
                     },
@@ -551,7 +551,7 @@ describe( 'handlePipelineEvent', function() {
                         "MetricName": "FailureLeadTime",
                         "Unit": "Seconds",
                         "Dimensions": [
-                            {Name: "PipelineName", Value: "my-pipeline"},
+                            { Name: "PipelineName", Value: "my-pipeline" },
                         ],
                         "Value": 100,
                     }
@@ -594,4 +594,217 @@ describe( 'handlePipelineEvent', function() {
     });
 });
 
+describe("generateDashboardTrend", () => {
+    let listMetricsStub;
+    let putDashboardSpy;
+    var sandbox = sinon.createSandbox();
+
+    function generateMetrics(n){
+        return [...Array(n).keys()].map(idx => {
+            return {
+                "Namespace": "Pipeline",
+                "Dimensions": [
+                    {
+                        "Name": "PipelineName",
+                        "Value": `my-pipeline-${idx}`
+                    }
+                ],
+                "MetricName": "SuccessCount"
+            }
+        });
+    }
+    let scenarios = [
+        {
+            description: "single pipeline",
+            uniquePipelines: 1,
+            metrics: {
+                "Metrics": [
+                    {
+                        "Namespace": "Pipeline",
+                        "Dimensions": [
+                            {
+                                "Name": "PipelineName",
+                                "Value": "my-pipeline"
+                            }
+                        ],
+                        "MetricName": "SuccessCount"
+                    },
+                    {
+                        "Namespace": "Pipeline",
+                        "Dimensions": [
+                            {
+                                "Name": "PipelineName",
+                                "Value": "my-pipeline"
+                            }
+                        ],
+                        "MetricName": "SuccessCycleTime"
+                    },
+                ]
+            },
+            event: {
+                "account": "123456789012",
+                "region": "ap-southeast-2",
+                "detail": {},
+                "detail-type": "Scheduled Event",
+                "source": "aws.events",
+                "time": "2019-03-01T01:23:45Z",
+                "id": "cdc73f9d-aea9-11e3-9d5a-835b769c0d9c",
+                "resources": [
+                    "arn:aws:events:ap-southeast-2:123456789012:rule/my-schedule"
+                ]
+            }
+        },
+        {
+            description: "multiple pipeline",
+            uniquePipelines: 2,
+            metrics: {
+                "Metrics": [
+                    {
+                        "Namespace": "Pipeline",
+                        "Dimensions": [
+                            {
+                                "Name": "PipelineName",
+                                "Value": "pipeline-1"
+                            }
+                        ],
+                        "MetricName": "SuccessCount"
+                    },
+                    {
+                        "Namespace": "Pipeline",
+                        "Dimensions": [
+                            {
+                                "Name": "PipelineName",
+                                "Value": "pipeline-2"
+                            }
+                        ],
+                        "MetricName": "SuccessCycleTime"
+                    },
+                ]
+            },
+            event: {
+                "account": "123456789012",
+                "region": "ap-southeast-2",
+                "detail": {},
+                "detail-type": "Scheduled Event",
+                "source": "aws.events",
+                "time": "2019-03-01T01:23:45Z",
+                "id": "cdc73f9d-aea9-11e3-9d5a-835b769c0d9c",
+                "resources": [
+                    "arn:aws:events:ap-southeast-2:123456789012:rule/my-schedule"
+                ]
+            }
+        },
+        {
+            description: "too many pipelines",
+            expectTruncated: true,
+            uniquePipelines: 50,
+
+            metrics: {
+                "Metrics": generateMetrics(50)
+            },
+            event: {
+                "account": "123456789012",
+                "region": "ap-southeast-2",
+                "detail": {},
+                "detail-type": "Scheduled Event",
+                "source": "aws.events",
+                "time": "2019-03-01T01:23:45Z",
+                "id": "cdc73f9d-aea9-11e3-9d5a-835b769c0d9c",
+                "resources": [
+                    "arn:aws:events:ap-southeast-2:123456789012:rule/my-schedule"
+                ]
+            }
+        }
+    ]
+
+    scenarios.forEach( scenario => {
+        describe(scenario.description, () => {
+            beforeEach(() => {
+
+                // https://github.com/dwyl/aws-sdk-mock/issues/118
+                // Cannot use aws-sdk-mock
+                putDashboardSpy = sandbox.stub().returns({
+                // putDashboardSpy = sinon.stub().returns({
+                    promise: () => Promise.resolve()
+                })
+        
+                listMetricsStub = sandbox.stub().returns({
+                // listMetricsStub = sinon.stub().returns({
+                    eachPage: (cb) => {
+                        cb(null, scenario.metrics)
+        
+                        cb(null, null) // no more pages
+                    }
+                })
+                // sinon.stub(awsSdk, 'CloudWatch').returns({
+                sandbox.stub(awsSdk, 'CloudWatch').returns({
+                    listMetrics: listMetricsStub,
+                    putDashboard: putDashboardSpy
+                });
+        
+                awsSdk.config.region = 'ap-southeast-2';
+            })
+        
+            afterEach(() => {
+                // awsSdk.CloudWatch.restore();
+                sandbox.restore();
+            })
+        
+            it("should generate a dashboard", () => {
+                return LambdaTester(index.generateDashboardTrend)
+                    .event(scenario.event)
+                    .expectResult((result, additional) => {
+                        expect(putDashboardSpy).to.have.callCount(1);
+                    });
+            })
+        
+            it('should generate 4 text widgets - to explain each metric', () => {
+                return LambdaTester(index.generateDashboardTrend)
+                    .event(scenario.event)
+                    .expectResult((result, additional) => {
+                        const dashboard = JSON.parse(putDashboardSpy.getCall(0).args[0].DashboardBody);
+                        const textWidgets = dashboard.widgets.filter(w => w.type === 'text');
+        
+                        expect(textWidgets.length).to.equal(4);
+        
+                    });
+            })
+        
+            if(scenario.expectTruncated) {
+                it('should report a maximum of 31 pipelines in the dashboard', ()=> {
+                    const consoleSpy = sandbox.spy(console, 'warn')
+                    return LambdaTester(index.generateDashboardTrend)
+                        .event(scenario.event)
+                        .expectResult((result, additional) => {
+                            expect(consoleSpy).to.have.been.calledWith("Maximum of 31 allowed in a single dashboard.  Some pipelines will not be reported.");
+                        });
+                })
+                it('should log a warning if pipelines will not be reported', ()=> {
+                    const consoleSpy = sandbox.spy(console, 'warn')
+                    return LambdaTester(index.generateDashboardTrend)
+                        .event(scenario.event)
+                        .expectResult((result, additional) => {
+                            expect(consoleSpy).to.have.been.calledWith("Maximum of 31 allowed in a single dashboard.  Some pipelines will not be reported.");
+                        });
+                })
+            } else {
+                it('should generate 4 dashboards per pipeline', () => {
+
+                    return LambdaTester(index.generateDashboardTrend)
+                        .event(scenario.event)
+                        .expectResult((result, additional) => {
+                            const dashboard = JSON.parse(putDashboardSpy.getCall(0).args[0].DashboardBody);
+                            const textWidgets = dashboard.widgets.filter(w => w.type === 'metric');
+            
+                            expect(textWidgets.length).to.equal(4 * scenario.uniquePipelines);
+                            
+                        });
+
+                    
+                })
+            }
+        })
+    })
+
+})
 


### PR DESCRIPTION
This PR creates a CloudWatch dashboard for graphing pipeline metric trends over time.

This pipeline-dashboard provides great tooling for assessing your project health.  However, without trend information, you cannot determine whether you are improving.

The pipeline dashboard includes the following trends:
* Deployment Frequency - aligns with the DORA State of DevOps report metric of the same name.
  * Annottations are included for "Elite" and "high" performing thresholds
* Lead Time - Graphs the same lead time metric as built into pipeline-dashboard - also aligns with the DORA metric.
  * Annottations are included for "Elite" thresholds
* MTTR - same as existing pipeline-dashboard
* MTBF - same as existing pipeline-dashboard

Current Limitations:
* The time units are not configurable - each dashboard is configured with set units, converting from seconds.  The choice has been made based on DORA metric recommendations.  If a user has really poor metrics, it could be a nudge for changing behaviour.  "If something hurts, do it more"!
* Due to CloudWatch limits, a maximum of ~30 pipelines can be displayed on a single dashboard.  This should be sufficient as an initial release - I'd consider > 30 pipelines in an account as a potential smell - using a multi-account strategy, fewer pipelines should be expected.
  * In the event of too many pipelines, a warning shall be logged.  In practice, without an alarm this is likely to be ignored, but is provided for information.