### PR TITLE
Upgrade to Nodejs12

### DIFF
--- a/codebuild.yml
+++ b/codebuild.yml
@@ -67,7 +67,7 @@ Resources:
         - Name: STAGING_BUCKET_PREFIX
           Value: !Ref StagingBucketPrefix
         Type: LINUX_CONTAINER
-        Image: aws/codebuild/nodejs:8.11.0
+        Image: aws/codebuild/nodejs:12
         ComputeType: BUILD_GENERAL1_SMALL
       Name: pipeline-dashboard
       Description: Stage pipeline-dashboard

--- a/package.json
+++ b/package.json
@@ -12,12 +12,9 @@
     "package": "npm run package:cfn && npm run package:template",
     "package:cfn": "mkdir -p .out && aws cloudformation package --template-file template.yml --s3-bucket ${npm_package_config_staging_bucket}-${npm_package_config_region} --output-template-file .out/template.yml",
     "package:template": "aws s3 cp .out/template.yml s3://${npm_package_config_staging_bucket}-${npm_package_config_region}/template.yml",
-
     "create-codebuild": "aws cloudformation create-stack --region ${npm_package_config_region} --stack-name pipeline-dashboard-codebuild --template-body file://codebuild.yml --capabilities CAPABILITY_NAMED_IAM ",
     "update-codebuild": "aws cloudformation update-stack --region ${npm_package_config_region} --stack-name pipeline-dashboard-codebuild --template-body file://codebuild.yml --capabilities CAPABILITY_NAMED_IAM --parameters ParameterKey=GitHubToken,UsePreviousValue=true",
-
     "deploy": "aws s3 cp s3://${npm_package_config_staging_bucket}-${npm_package_config_region}/template.yml .out/template.yml && aws cloudformation deploy --template-file .out/template.yml --stack-name $npm_package_config_stack_name --capabilities CAPABILITY_NAMED_IAM --region $npm_package_config_region ",
-
     "test": "node ./node_modules/jshint/bin/jshint index.js src/*.js && node ./node_modules/mocha/bin/_mocha"
   },
   "repository": {
@@ -31,13 +28,13 @@
   },
   "homepage": "https://github.com/stelligent/pipeline-dashboard#readme",
   "devDependencies": {
-    "aws-sdk-mock": "^1.7.0",
+    "aws-sdk-mock": "^5.0.0",
     "chai": "^4.1.2",
     "jshint": "^2.9.5",
-    "lambda-tester": "^3.1.0",
-    "mocha": "^4.0.1",
-    "sinon": "^4.0.1",
-    "sinon-chai": "^2.14.0"
+    "lambda-tester": "^4.0.1",
+    "mocha": "^7.0.0",
+    "sinon": "^8.1.0",
+    "sinon-chai": "^3.4.0"
   },
   "dependencies": {
     "aws-sdk": "^2.138.0"

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -111,7 +111,7 @@ Resources:
         - Name: STAGING_BUCKET_PREFIX
           Value: !Ref StagingBucketPrefix
         Type: LINUX_CONTAINER
-        Image: aws/codebuild/nodejs:8.11.0
+        Image: aws/codebuild/nodejs:12
         ComputeType: BUILD_GENERAL1_SMALL
       Name: pipeline-dashboard
       Description: Stage pipeline-dashboard

--- a/template-sar.yml
+++ b/template-sar.yml
@@ -11,7 +11,7 @@ Resources:
     Properties:
       Description: Create CloudWatch metrics from AWS CodePipeline events
       Handler: index.handlePipelineEvent
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       CodeUri: s3://pipeline-dashboard-node-0811-us-east-1/2a5aeb4cc9e66058ac7fcd00bd33da64
       Events:
         PipelineEventRule:
@@ -33,7 +33,7 @@ Resources:
     Properties:
       Description: Build CloudWatch dashboard from CloudWatch metrics
       Handler: index.generateDashboard
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       CodeUri: s3://pipeline-dashboard-node-0811-us-east-1/2a5aeb4cc9e66058ac7fcd00bd33da64
       Timeout: 60
       Events:

--- a/template.yml
+++ b/template.yml
@@ -11,7 +11,7 @@ Resources:
     Properties:
       Description: Create CloudWatch metrics from CodePipeline events
       Handler: index.handlePipelineEvent
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       CodeUri: .
       Events:
         PipelineEventRule:
@@ -33,7 +33,7 @@ Resources:
     Properties:
       Description: Build CloudWatch dashboard from CloudWatch metrics
       Handler: index.generateDashboard
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       CodeUri: .
       Timeout: 60
       Events:


### PR DESCRIPTION
As AWS deprecated support of nodejs8 runtime, this change updates the lambda runtime to nodejs12. Also, dependencies have been updated to latest version.