### PR TITLE
Updating node version to 16 since version 12 is now deprecated

### DIFF
--- a/codebuild.yml
+++ b/codebuild.yml
@@ -67,7 +67,7 @@ Resources:
         - Name: STAGING_BUCKET_PREFIX
           Value: !Ref StagingBucketPrefix
         Type: LINUX_CONTAINER
-        Image: aws/codebuild/nodejs:12
+        Image: aws/codebuild/nodejs:16
         ComputeType: BUILD_GENERAL1_SMALL
       Name: pipeline-dashboard
       Description: Stage pipeline-dashboard

--- a/template-sar.yml
+++ b/template-sar.yml
@@ -11,7 +11,7 @@ Resources:
     Properties:
       Description: Create CloudWatch metrics from AWS CodePipeline events
       Handler: index.handlePipelineEvent
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       CodeUri: s3://pipeline-dashboard-node-0811-us-east-1/2a5aeb4cc9e66058ac7fcd00bd33da64
       Events:
         PipelineEventRule:
@@ -33,7 +33,7 @@ Resources:
     Properties:
       Description: Build CloudWatch dashboard from CloudWatch metrics
       Handler: index.generateDashboard
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       CodeUri: s3://pipeline-dashboard-node-0811-us-east-1/2a5aeb4cc9e66058ac7fcd00bd33da64
       Timeout: 60
       Events:

--- a/template.yml
+++ b/template.yml
@@ -19,7 +19,7 @@ Resources:
     Properties:
       Description: Create CloudWatch metrics from CodePipeline events
       Handler: index.handlePipelineEvent
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       CodeUri:
         Bucket: !Ref BucketName
         Key: !Ref CodeKey
@@ -43,7 +43,7 @@ Resources:
     Properties:
       Description: Build CloudWatch dashboard from CloudWatch metrics
       Handler: index.generateDashboard
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       CodeUri:
         Bucket: !Ref BucketName
         Key: !Ref CodeKey


### PR DESCRIPTION
From Nov, node version 12 is being deprecated. Upgrading the node version to 16.